### PR TITLE
Fix indexing errors

### DIFF
--- a/concept_formation/cobweb.py
+++ b/concept_formation/cobweb.py
@@ -34,6 +34,21 @@ class CobwebTree(object):
     def __str__(self):
         return str(self.root)
 
+    def _sanity_check_instance(self,instance):
+        for attr in instance:
+            if not isinstance(attr,str):
+                raise ValueError('Invalid attribute: '+str(attr)+
+                    ' of type: '+str(type(attr))+
+                    ' in instance: '+str(instance)+
+                    ',\n'+type(self).__name__+
+                    ' only works with constant attributes of type str.')
+            if not isinstance(instance[attr],collections.Hashable):
+                raise ValueError('Invalid value: '+str(instance[attr])+
+                    ' of type: '+str(type(instance[attr]))+
+                    ' in instance: '+str(instance) +
+                    ',\n'+type(self).__name__+
+                    ' only works with Hashable values.')
+
     def ifit(self, instance):
         """
         Incrementally fit a new instance into the tree and return its resulting
@@ -51,19 +66,7 @@ class CobwebTree(object):
 
         .. seealso:: :meth:`CobwebTree.cobweb`
         """
-        for attr in instance:
-            if not isinstance(attr,str):
-                raise ValueError('Invalid attribute: '+str(attr)+
-                    ' of type: '+str(type(attr))+
-                    ' in instance: '+str(instance)+
-                    ',\n'+type(self).__name__+
-                    ' only works with constant attributes of type str.')
-            if not isinstance(instance[attr],collections.Hashable):
-                raise ValueError('Invalid value: '+str(instance[attr])+
-                    ' of type: '+str(type(instance[attr]))+
-                    ' in instance: '+str(instance) +
-                    ',\n'+type(self).__name__+
-                    ' only works with Hashable values.')
+        self._sanity_check_instance(instance) 
         return self.cobweb(instance)
 
     def fit(self, instances, iterations=1, randomize_first=True):
@@ -249,6 +252,7 @@ class CobwebTree(object):
         :return: A completed instance
         :rtype: instance
         """
+        self._sanity_check_instance(instance)
         temp_instance = {a:instance[a] for a in instance}
         probs = {a:1.0 for a in instance}
         concept = self._cobweb_categorize(temp_instance)
@@ -281,6 +285,7 @@ class CobwebTree(object):
 
         .. seealso:: :meth:`CobwebTree.cobweb`
         """
+        self._sanity_check_instance(instance)
         return self._cobweb_categorize(instance)
     
     def train_from_json(self, filename, length=None):

--- a/concept_formation/cobweb.py
+++ b/concept_formation/cobweb.py
@@ -5,6 +5,7 @@ from __future__ import division
 from random import shuffle
 from random import random
 import json
+import collections
 
 from concept_formation.utils import weighted_choice
 from concept_formation.utils import most_likely_choice
@@ -50,6 +51,19 @@ class CobwebTree(object):
 
         .. seealso:: :meth:`CobwebTree.cobweb`
         """
+        for attr in instance:
+            if not isinstance(attr,str):
+                raise ValueError('Invalid attribute: '+str(attr)+
+                    ' of type: '+str(type(attr))+
+                    ' in instance: '+str(instance)+
+                    ',\n'+type(self).__name__+
+                    ' only works with constant attributes of type str.')
+            if not isinstance(instance[attr],collections.Hashable):
+                raise ValueError('Invalid value: '+str(instance[attr])+
+                    ' of type: '+str(type(instance[attr]))+
+                    ' in instance: '+str(instance) +
+                    ',\n'+type(self).__name__+
+                    ' only works with Hashable values.')
         return self.cobweb(instance)
 
     def fit(self, instances, iterations=1, randomize_first=True):
@@ -970,7 +984,7 @@ class CobwebNode(object):
            children_count += c.num_concepts() 
         return 1 + children_count 
 
-    def output_json(self, limit_by_performance):
+    def output_json(self, limit_by_performance=False):
         """
         Outputs the categorization tree in JSON form
 
@@ -1000,10 +1014,10 @@ class CobwebNode(object):
                 tot_dec += self.correct_at_decendents[k].mean
             if tot_at < tot_dec:
                 for child in self.children:
-                    output["children"].append(child.output_json())
+                    output["children"].append(child.output_json(limit_by_performance))
         else:
              for child in self.children:
-                    output["children"].append(child.output_json())
+                    output["children"].append(child.output_json(limit_by_performance))
 
         output['counts'] = temp
 

--- a/concept_formation/structure_mapper.py
+++ b/concept_formation/structure_mapper.py
@@ -14,7 +14,6 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 from __future__ import division
 from itertools import permutations
-import json
 
 from py_search.search import Problem
 from py_search.search import Node

--- a/concept_formation/structure_mapper.py
+++ b/concept_formation/structure_mapper.py
@@ -419,6 +419,18 @@ def _check_instance(instance):
                 ',\nStructureMapper requires that attributes be of type str or tuple.')
         if isinstance(instance[attr],dict):
             _check_instance(instance[attr])
+        if isinstance(attr,tuple):
+            _check_relation(attr,instance)
+
+def _check_relation(relation, instance):
+    for v in relation:
+        if not isinstance(v,str) and not isinstance(v,tuple):
+            raise(ValueError('Invalid relation value: '+str(v)+
+                ' of type: '+str(type(v))+
+                ' in instance: '+str(instance)+
+                ',\nStructureMapper requires that values inside relation tuples be of type str or tuple.'))
+        if isinstance(v,tuple):
+            _check_relation(v,instance)
 
 class StructureMapper(Preprocessor):
     """

--- a/concept_formation/structure_mapper.py
+++ b/concept_formation/structure_mapper.py
@@ -403,35 +403,6 @@ def is_partial_match(iAttr, cAttr, mapping, unnamed):
 
     return iAttr == cAttr
 
-def _check_instance(instance):
-    """
-    Checks the attributes of an instance to ensure they are properly
-    subscriptable types and throws an excpetion if they are not.
-    Lots of sub-processes in the structure mapper freak out if you have
-    non-str non-tuple attributes so I decided it was best to do a one
-    time check at the first call to transform.
-    """
-    for attr in instance:
-        if not isinstance(attr,str) and not isinstance(attr,tuple):
-            raise ValueError('Invalid attribute: '+str(attr)+
-                ' of type: '+str(type(attr))+
-                ' in instance: '+str(instance)+
-                ',\nStructureMapper requires that attributes be of type str or tuple.')
-        if isinstance(instance[attr],dict):
-            _check_instance(instance[attr])
-        if isinstance(attr,tuple):
-            _check_relation(attr,instance)
-
-def _check_relation(relation, instance):
-    for v in relation:
-        if not isinstance(v,str) and not isinstance(v,tuple):
-            raise(ValueError('Invalid relation value: '+str(v)+
-                ' of type: '+str(type(v))+
-                ' in instance: '+str(instance)+
-                ',\nStructureMapper requires that values inside relation tuples be of type str or tuple.'))
-        if isinstance(v,tuple):
-            _check_relation(v,instance)
-
 class StructureMapper(Preprocessor):
     """
     Flatten the instance, perform structure mapping to the concept, rename
@@ -475,7 +446,6 @@ class StructureMapper(Preprocessor):
         return {self.reverse_mapping[o]: o for o in self.reverse_mapping}
     
     def transform(self, instance):
-        _check_instance(instance)
         instance = self.pipeline.transform(instance)
         mapping = flat_match(self.concept, instance,
                              beam_width=self.beam_width,

--- a/concept_formation/structure_mapper.py
+++ b/concept_formation/structure_mapper.py
@@ -464,7 +464,7 @@ class StructureMapper(Preprocessor):
         return {self.reverse_mapping[o]: o for o in self.reverse_mapping}
     
     def transform(self, instance):
-        check_instance(instance)
+        _check_instance(instance)
         instance = self.pipeline.transform(instance)
         mapping = flat_match(self.concept, instance,
                              beam_width=self.beam_width,

--- a/concept_formation/trestle.py
+++ b/concept_formation/trestle.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 from __future__ import division
 from math import sqrt
 from math import pi
+import collections
 
 from concept_formation.cobweb3 import Cobweb3Tree
 from concept_formation.cobweb3 import Cobweb3Node
@@ -91,6 +92,43 @@ class TrestleTree(Cobweb3Tree):
         self.root = Cobweb3Node()
         self.root.tree = self
 
+    def _sanity_check_instance(self,instance):
+        """
+        Checks the attributes of an instance to ensure they are properly
+        subscriptable types and throws an excpetion if they are not.
+        Lots of sub-processes in the structure mapper freak out if you have
+        non-str non-tuple attributes so I decided it was best to do a one
+        time check at the first call to transform.
+        """
+        for attr in instance:
+            if not isinstance(attr,str) and not isinstance(attr,tuple):
+                raise ValueError('Invalid attribute: '+str(attr)+
+                    ' of type: '+str(type(attr))+
+                    ' in instance: '+str(instance)+
+                    ',\n'+type(self).__name__+
+                    ' requires that attributes be of type str or tuple.')
+            if isinstance(instance[attr],dict):
+                self._sanity_check_instance(instance[attr])
+            if isinstance(attr,tuple):
+                self._sanity_check_instance(attr,instance)
+            if not isinstance(instance[attr],collections.Hashable):
+                raise ValueError('Invalid value: '+str(instance[attr])+
+                    ' of type: '+str(type(instance[attr]))+
+                    ' in instance: '+str(instance) +
+                    ',\n'+type(self).__name__+
+                    ' only works with Hashable values.')
+
+    def _sanity_check_relation(self,relation, instance):
+        for v in relation:
+            if not isinstance(v,str) and not isinstance(v,tuple):
+                raise(ValueError('Invalid relation value: '+str(v)+
+                    ' of type: '+str(type(v))+
+                    ' in instance: '+str(instance)+
+                    ',\n'+type(self).__name__+
+                    'requires that values inside relation tuples be of type str or tuple.'))
+            if isinstance(v,tuple):
+                self._sanity_check_relation(v,instance)
+
     def ifit(self, instance):
         """
         Incrementally fit a new instance into the tree and return its resulting
@@ -111,6 +149,7 @@ class TrestleTree(Cobweb3Tree):
 
         .. seealso:: :meth:`TrestleTree.trestle`
         """
+        self._sanity_check_instance(instance)
         return self.trestle(instance)
 
     def _trestle_categorize(self, instance):
@@ -178,6 +217,7 @@ class TrestleTree(Cobweb3Tree):
 
         .. seealso:: :meth:`TrestleTree.trestle`
         """
+        self._sanity_check_instance(instance)
         return self._trestle_categorize(instance)
 
     def trestle(self, instance):
@@ -196,6 +236,7 @@ class TrestleTree(Cobweb3Tree):
         :return: A concept describing the instance
         :rtype: CobwebNode
         """
+        self._sanity_check_instance(instance)
         structure_mapper = StructureMapper(self.root,
                                            gensym=self.gensym,
                                            beam_width=self.beam_width,


### PR DESCRIPTION
This is a branch meant to address the #8 issue of numerical keys throwing indexing errors. Basically we've been assuming that attribute keys within an instance dictionary are subscriptable types (either `str`, or `tuple`). If you tried to pass in a dictionary with some other type as a key (which is totally valid in python) you would get some exception with a deep stack trace from the internals of the concept formation algorithm. Instead I've put a basic check at the root call (`ifit()` in the case of CobwebTree and Cobweb3Tree, and `transform()` in the case of the StructureMapper for Trestle) that checks to make sure all of the attributes will play nice with the internals of the algorithm and throws a more meaningful trace if they won't. I've done some testing and found that this adds a negligible overhead for correctly formatted instances.